### PR TITLE
docs: Remove redundant "and"

### DIFF
--- a/.github/ISSUE_TEMPLATE/tech-debt.md
+++ b/.github/ISSUE_TEMPLATE/tech-debt.md
@@ -1,6 +1,6 @@
 ---
 name: Tech debt
-about: Track TODOs and etc
+about: Track TODOs, etc.
 title: 'Tech debt: '
 labels: 'tech-debt'
 assignees: ''


### PR DESCRIPTION
etc, aka "et cetera" means "and others", "and so on, and so on", and
similar phrases, making the additional "and" unnecessary.

https://www.dictionary.com/browse/et-cetera

---

## How I am structuring my commits

<!-- Delete the line that doesn't apply to you -->

I am going to **write individual commits for review**
