### PR TITLE
Add reference to POSTMAN collection in issue

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -29,6 +29,7 @@ Does this change impact:
 - [ ] Mobile API
 - [ ] v2 API
 - [ ] GraphQL API
+- [ ] Postman Collection
 - [ ] Spreadsheet uploader
 - [ ] 3Sixty1 Reports
 


### PR DESCRIPTION
We now have POSTMAN collections as references for clients who want to use our API's (https://api.marketplacer.com/graphql/overview/ & https://api.marketplacer.com/v2/). We need to make sure we keep the collections up to date when changes are made to our APIs, so trying to make sure we don't forgot about it.