### PR TITLE
chore: add section to issue templates for information security

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -33,6 +33,12 @@ Does this change impact:
 - [ ] Spreadsheet uploader
 - [ ] 3Sixty1 Reports
 
+### Security requirements
+
+What Information Security Controls are required to be considered as part of this feature?
+
+*Refer to the [Threat Modeling introduction](https://app.tettra.co/teams/marketplacer/pages/threat-modelling) and the [Attack Surface Analysis Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Attack_Surface_Analysis_Cheat_Sheet.html) for guidance on how to assess the relevant information security controls.*
+
 ### References
 
 - Links to designs, API docs, Github cards

--- a/.github/ISSUE_TEMPLATE/tech-debt.md
+++ b/.github/ISSUE_TEMPLATE/tech-debt.md
@@ -24,5 +24,11 @@ e.g. deadlines
 ### optional: What's the risk of doing nothing?
 e.g. it will be harder to extend feature Y in Z direction
 
+### Security requirements
+
+What Information Security Controls are required to be considered as part of fixing this tech debt?
+
+*Refer to the [Threat Modeling introduction](https://app.tettra.co/teams/marketplacer/pages/threat-modelling) and the [Attack Surface Analysis Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Attack_Surface_Analysis_Cheat_Sheet.html) for guidance on how to assess the relevant information security controls.*
+
 ### optional: References
 Add any other context or tickets relating to the problem here.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -14,4 +14,18 @@ The first paragraph of description will show up on #changelog. Replace it with s
 - [ ] Deployed to **[pick an environment name, you clod]**
 - [ ] PR has appropriate labels added (needs-testing, etc.)
 
+**Information Security Requirements:**
+
+Detail how this addresses security requirements identified during the design stage (see the linked issue)
+
+Detail how you have tested the following:
+  * authentication controls
+  * authorisation controls
+  * data and input/output validation controls
+  * session management controls
+  * error and exception handling controls
+
+Verify that you have checked the code for backdoors and other malicious content
+
+
 Resolves #github-issue-number


### PR DESCRIPTION
As part of SAD-60, we need to make sure that we capture the information security controls required as part of the design phase of any project. This adds a heading for this under our standard issue and PR templates.
