### PR TITLE
chore: notify data platform team when schemata change

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -27,6 +27,7 @@ The following sections are required to be completed before merging your PR. It e
 - [ ] Data and input/output validation controls (SQL injection, XSS attacks, file validation, type conversion)
 - [ ] Error and exception handling controls (transaction rollbacks, parsing external errors)
 - [ ] Any newly introduced PII or confidential data is appropriately handled.  This includes external systems like Rollbar and Datadog, but also applies internally to Dupliplacer, Umbrella_Placer and the like.
+- [ ] Any schema changes have been notified to the data platform team in #data-change-notifications on slack.
 - [ ] Aware of the downstream/upstream effects this change will have. The Marketplacer ecosystem is beyond complicated and now has many system dependencies.  Take the time to understand how your change interacts with them and speak to some teams if you need to (MConnect, Cerberus, Graphql, API V2, Headless, Connected, Fullstack, Minsights, Umbrella_Placer, Spreadsheet Uploaders, MStores, MultiStores, and more!)
 - [ ] Supporting documentation published. A release is not just pushing a code change, it's also communicating it.
 In-App documentation, Knowledgebase, API Docs, Tettra Docs, Postman Collection, Lucid Charts, and your PM knows what's up.


### PR DESCRIPTION
The data platform team can get ETL failures if the source schemata
change unexpectedly. Add a step to the release checklist for notifying
the data platform team of any schema changes

**Release Checklist:**
- [x] Authentication is on point (you are who you say you are)
- [x] Authorisation is on point (you are allowed to access this)
- [x] Data and input/output validation controls (SQL injection, XSS attacks, file validation, type conversion)
- [x] Error and exception handling controls (transaction rollbacks, parsing external errors)
- [x] Any newly introduced PII or confidential data is appropriately handled.  This includes external systems like Rollbar and Datadog, but also applies internally to Dupliplacer, Umbrella_Placer and the like.
- [x] Aware of the downstream/upstream effects this change will have. The Marketplacer ecosystem is beyond complicated and now has many system dependencies.  Take the time to understand how your change interacts with them and speak to some teams if you need to (MConnect, Cerberus, Graphql, API V2, Headless, Connected, Fullstack, Minsights, Umbrella_Placer, Spreadsheet Uploaders, MStores, MultiStores, and more!)

Added to the BEWG notion board for discussion

- [x] Supporting documentation published. A release is not just pushing a code change, it's also communicating it.
In-App documentation, Knowledgebase, API Docs, Tettra Docs, Postman Collection, Lucid Charts, and your PM knows what's up.
